### PR TITLE
Corrected _fill check in ellipse::draw.

### DIFF
--- a/seeed_graphics_base.cpp
+++ b/seeed_graphics_base.cpp
@@ -99,7 +99,7 @@ void rectangle::draw() {
 
 void ellipse::draw() {
     auto p = adjust(_width, _height);
-    if (_fill){
+    if (_fill != transparent) {
         spr.fillEllipse(_x, _y, _width / 2, _height / 2, _fill);
     }
     spr.drawEllipse(_x, _y, _width / 2, _height / 2, _color);


### PR DESCRIPTION
The test for filled ellipses in ellipse::draw is incorrect.